### PR TITLE
Added windows support to exobot-build

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -2,7 +2,7 @@
 
 const spawn = require('child_process').spawn;
 const blueprintsPath = `${__dirname}/blueprints.config.js`;
-
+let build;
 const buildArgs = ['-b', blueprintsPath, '-p'];
 if (process.argv.length > 2) {
   if (process.argv[2] === '-w' || process.argv[2] === '--watch') {
@@ -10,7 +10,11 @@ if (process.argv.length > 2) {
   }
 }
 
-const build = spawn('npm', ['run', 'blueprints', '--', ...buildArgs]);
+if (process.platform === 'win32') {
+  build = spawn('blueprints', buildArgs, {shell: 'cmd.exe'});
+} else {
+  build = spawn('blueprints', buildArgs);
+}
 
 build.stdout.on('data', (data) => {
   console.log(data.toString());


### PR DESCRIPTION
Tested on Windows 10 x64.  This is untested on other platforms.
